### PR TITLE
Add babel-cli to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "lex": "^1.7.9"
   },
   "devDependencies": {
+    "babel-cli": "6.24.1",
     "babel-eslint": "7.1.1",
     "babel-plugin-transform-flow-strip-types": "6.22.0",
     "documentation": "4.0.0-beta.18",


### PR DESCRIPTION
@dickeyxxx `npm install` fails because babel executable cannot be found